### PR TITLE
Fix PyPi package and bump version

### DIFF
--- a/client/MANIFEST.in
+++ b/client/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/client/setup.py
+++ b/client/setup.py
@@ -10,7 +10,7 @@ with open("./README.md") as f:
 
 setuptools.setup(
     name="streamsql",
-    version="2.0.0",
+    version="2.0.1",
     url="https://github.com/streamsql-io/streamsql",
     description="Python SDK for the StreamSQL feature store",
     long_description=long_description,


### PR DESCRIPTION
Version 2.0.0 did not include requirements.txt in MANIFEST.in, this one
does. It also bumps the version to 2.0.1