### PR TITLE
Create Makefile for Python Client

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -37,12 +37,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-${{ matrix.python }}-venv-
     - name: Install virtualenv
-      if: runner.os != 'Linux' && steps.venvcache.outputs.cache-hit != 'true'
+      if: runner.os != 'Linux'
       run: |
         make install-py-setuptools
         make install-venv
     - name: Install virtualenv on Ubuntu
-      if: runner.os == 'Linux' && steps.venvcache.outputs.cache-hit != 'true'
+      if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y python3-setuptools python3-venv
     - name: Setup virtualenv

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   python:
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        working-directory: "./client"
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]

--- a/client/Makefile
+++ b/client/Makefile
@@ -40,7 +40,7 @@ test: install-dev
 
 # format formats all python files in-place.
 format: install-dev
-	$(FORMAT) -i -r -p ./
+	$(FORMAT) -i -r -p ./streamsql ./tests
 
 clean:
 	rm install-dev
@@ -48,7 +48,7 @@ clean:
 
 # returns a non-zero value if code is not formatted.
 check-format: install-dev
-	$(FORMAT) -r -p -q ./
+	$(FORMAT) -r -p -q ./streamsql ./tests
 
 # install-dev installs all dependencies for python development of streamsql.
 install-dev: $(VENV) ./requirements.txt

--- a/client/Makefile
+++ b/client/Makefile
@@ -36,11 +36,11 @@ coverage.xml: install-dev
 
 # test also generates a coverage file.
 test: install-dev
-	$(COVERAGE) run --source streamsql -m pytest --verbose ./client/tests
+	$(COVERAGE) run --source streamsql -m pytest --verbose ./tests
 
 # format formats all python files in-place.
 format: install-dev
-	$(FORMAT) -i -r -p ./client/
+	$(FORMAT) -i -r -p ./
 
 clean:
 	rm install-dev
@@ -48,11 +48,11 @@ clean:
 
 # returns a non-zero value if code is not formatted.
 check-format: install-dev
-	$(FORMAT) -r -p -q ./client/
+	$(FORMAT) -r -p -q ./
 
 # install-dev installs all dependencies for python development of streamsql.
-install-dev: $(VENV) ./client/requirements.txt
-	${PYCMD} -m pip install -e client && touch install-dev
+install-dev: $(VENV) ./requirements.txt
+	${PYCMD} -m pip install -e . && touch install-dev
 
 # Create a Python virtual environment under ./venv
 $(VENV):


### PR DESCRIPTION
Keeping a sub-Makefile for each project will be easier to maintain
than trying to keep one large one in the base directory.